### PR TITLE
Support yarn 1.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "Florent Benoit",
   "license": "EPL-2.0",
   "bin": {
-    "theia:plugin": "./dist/index.js",
     "theia-plugin": "./dist/index.js"
   },
   "dependencies": {


### PR DESCRIPTION
Adopt package.json to build project with yarn 1.21.1.

Related issue: https://github.com/eclipse/theia-plugin-packager/issues/8

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>