### PR TITLE
fix(yarn): Always use JSON output of the yarn workspaces command

### DIFF
--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -31,7 +31,7 @@ export class Yarn {
      */
     public static readonly YARN_GET_CONFIG = 'yarn config current --json';
 
-    public static readonly YARN_GET_WORKSPACES = "yarn workspaces info --json";
+    public static readonly YARN_GET_WORKSPACES = "yarn workspaces --json info";
 
     constructor(readonly rootFolder: string,
         private readonly dependenciesDirectory: string,


### PR DESCRIPTION
With yarn v1.22.x the output is not rendered in JSON when it's the last parameter

Change-Id: I63d7f805c36ed429829a91fc583a16350d39dde8
Signed-off-by: Florent Benoit <fbenoit@redhat.com>