### PR TITLE
Fix yarn workspace handling on Windows

### DIFF
--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -99,7 +99,8 @@ export class Yarn {
             // search if we've a location matching
             const matchingElements = Object.keys(jsonWorkspaces).filter(entry => {
                 if (jsonWorkspaces[entry].location) {
-                    if (currentDir.endsWith(jsonWorkspaces[entry].location)) {
+                    // 'yarn workspaces info' always returns paths separated by forward slash. Convert to local OS separator to compare with cwd.
+                    if (currentDir.endsWith(jsonWorkspaces[entry].location.replace(/\//g, path.sep))) {
                         return true;
                     }
                 }


### PR DESCRIPTION
This PR fixes dependency resolution in yarn workspaces on Windows.

The `yarn workspaces info` output always uses forward slash separator, even on Windows. This was being compared to `process.cwd`, which uses the OS path separator.